### PR TITLE
Disable default features for the image crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["cdg", "karaoke"]
 
 [dependencies]
 cdg = "0.1"
-image = "0.23"
+image = { version = "0.23", default-features = false }


### PR DESCRIPTION
We don't need JPEG, GIF, etc. support so depending on the whole
dependency chain of them is not needed and only wastes CPU time.

On my system this speeds up a clean debug build from 12s to 4s.